### PR TITLE
Supplement (2.13.0...2.13.1)

### DIFF
--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -938,8 +938,12 @@ FILENAME_HEAD: "文件名",
 
   //IFrameActionsMenu.tsx
   NARROW_TO_HEADING: "缩放至标题",
+  PIN_VIEW: "锁定视图",
+  DO_NOT_PIN_VIEW: "不锁定视图",
   NARROW_TO_BLOCK: "缩放至块",
   SHOW_ENTIRE_FILE: "显示全部",
+  SELECT_SECTION: "从文档选择章节",
+  SELECT_VIEW: "从 base 选择视图",
   ZOOM_TO_FIT: "缩放至合适大小",
   RELOAD: "重载链接",
   OPEN_IN_BROWSER: "在浏览器中打开",


### PR DESCRIPTION
Excalidraw 插件 2.13.0 到 2.13.1 有新增的翻译项，暂时没看到对应更新，怕久了忘了，因为你这儿也没开 Issues 所以直接 PR 了。

你可以在下面这个链接中查验这个事情，会对比 2.13.0 到 2.13.1 的差异，在此之上我让它直接跳转到 en.ts 的修改。注意跳转会显示在页面最上端而不是中央：

https://github.com/zsviczian/obsidian-excalidraw-plugin/compare/2.13.0...2.13.1#diff-c38aa16c41b3b29b50dabe9019a87924f34a96ad250e28a12ea8375d856c0e4b

翻译中的 base 是 Ob 1.9 新增的，推荐保留，等出官方翻译了再统一替换。当然直接留着也挺好，比较清晰，方便大家对应。

如果你合并了这个分支，会直接追加到你对主仓库的 PR 中，不需要重新 PR。事实上开了 PR 后，新加的提交或者强制推送都会自动记录上，它只会检验你最后展现的结果。所以你如果平时有什么要修改的话，也不用一直开分支，直接 push -f 就可以了。

<img width="413" alt="image" src="https://github.com/user-attachments/assets/12faf2b2-cee7-49f8-a7a4-33b98eec5cb7" />
