### PR TITLE
Unify whitespace across translations (zh-cn.ts)

### DIFF
--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -146,7 +146,7 @@ export default {
     "箭头和线元素的链接无法通过 " + labelCTRL() + " + 点击元素来导航，因为这也会激活线编辑器。\n" +
     "请使用右键上下文菜单打开链接，或点击元素右上角的链接指示器。\n",
   FILENAME_INVALID_CHARS:
-    '文件名不能含有以下符号： * " \\  < > : | ? #',
+    '文件名不能含有以下符号： * " \\ < > : | ? #',
   FORCE_SAVE:
     "保存（同时更新嵌入了该绘图的 Markdown 文档）",
   RAW: "文本元素正以原文（RAW）模式显示链接。\n点击切换到预览（PREVIEW）模式",
@@ -198,8 +198,6 @@ export default {
   SEARCH_SHOWHIDE_ARIA: "显示/隐藏搜索栏" ,
   SEARCH_NEXT: "下一个",
   SEARCH_PREVIOUS: "上一个",
-
-
 
   //settings.ts
   NOTEBOOKLM_LINK_ARIA: "向 NotebookLM 咨询有关插件的帮助。此模型已预加载了我所有的视频转录、发布说明和其他有用内容。与 NotebookLM 聊天，探索我的 250+ 视频和 Excalidraw 文档。" ,
@@ -331,7 +329,7 @@ export default {
     "这将使您能够轻松阅读和编辑 JSON 字符串。" +
     "一旦您切换回 Excalidraw 视图并保存绘图（Ctrl+S），绘图将再次被压缩。<br>" +
     "我建议关闭此功能，因为这可以获得更小的文件尺寸，并避免在 Obsidian 搜索中出现不必要的结果。 " +
-    "您始终可以使用命令面板中的“Excalidraw: 解压缩当前 Excalidraw 文件”命令"+
+    "您始终可以使用命令面板中的“Excalidraw: 解压缩当前 Excalidraw 文件”命令" +
     "在需要阅读或编辑时手动解压缩绘图 JSON。",
   AUTOSAVE_INTERVAL_DESKTOP_NAME: "桌面端自动保存时间间隔",
   AUTOSAVE_INTERVAL_DESKTOP_DESC:
@@ -413,7 +411,7 @@ FILENAME_HEAD: "文件名",
   DISABLE_SINGLE_FINGER_PANNING_NAME: "启用手写模式下的单指平移功能",
   SHOW_PEN_MODE_FREEDRAW_CROSSHAIR_NAME: "在触控笔模式下显示十字准星（+）",
   SHOW_PEN_MODE_FREEDRAW_CROSSHAIR_DESC:
-    "在触控笔模式下使用涂鸦功能会显示十字准星 <b><u>打开:</u></b> 显示 <b><u>关闭:</u></b> 隐藏<br>"+
+    "在触控笔模式下使用涂鸦功能会显示十字准星 <b><u>打开:</u></b> 显示 <b><u>关闭:</u></b> 隐藏<br>" +
     "效果取决于设备。十字准星通常在绘图板、MS Surface 上可见。但在 iOS 上不可见。",
   SHOW_DRAWING_OR_MD_IN_HOVER_PREVIEW_NAME: "在鼠标悬停预览时将 Excalidraw 文件渲染为图片",
   SHOW_DRAWING_OR_MD_IN_HOVER_PREVIEW_DESC:
@@ -465,7 +463,7 @@ FILENAME_HEAD: "文件名",
     "<b><u>开启：</u></b>更改网格颜色以匹配画布颜色<br><b><u>关闭：</u></b>将以下颜色用作网格颜色",
   GRID_COLOR_NAME: "网格颜色",
   GRID_OPACITY_NAME: "网格透明度",
-  GRID_OPACITY_DESC: "网格透明度还将控制将箭头绑定到元素时绑定框的透明度。<br>"+
+  GRID_OPACITY_DESC: "网格透明度还将控制将箭头绑定到元素时绑定框的透明度。<br>" +
     "设置网格的不透明度。 0 表示完全透明，100 表示完全不透明。",
   GRID_DIRECTION_NAME: "网格方向" ,
   GRID_DIRECTION_DESC: "第一个开关显示/隐藏水平网格，第二个开关显示/隐藏垂直网格。" ,
@@ -489,7 +487,7 @@ FILENAME_HEAD: "文件名",
   DRAG_MODIFIER_NAME: "修饰键",
   DRAG_MODIFIER_DESC: "在您按住点击链接或拖放元素时，可以触发某些行为。您可以为这些行为添加修饰键。" +
     "Excalidraw 不会检查您的设置是否合理，因此请谨慎设置，避免冲突。" +
-    "以下选项在苹果和非苹果设备上区别很大，如果您在多个硬件平台上使用 Obsidian，需要分别进行设置。"+
+    "以下选项在苹果和非苹果设备上区别很大，如果您在多个硬件平台上使用 Obsidian，需要分别进行设置。" +
     "选项里的 4 个开关依次代表 " +
     (DEVICE.isIOS || DEVICE.isMacOS ? "Shift, CMD, OPT, CONTROL." : "Shift, Ctrl, Alt, META (Win 键)。"),
   LONG_PRESS_DESKTOP_NAME: "长按打开（电脑端）",
@@ -724,13 +722,13 @@ FILENAME_HEAD: "文件名",
   EXPORT_PNG_NAME: "自动导出 PNG 副本",
   EXPORT_PNG_DESC: "和“自动导出 SVG 副本”类似，但是导出格式为 *.PNG。",
   EXPORT_BOTH_DARK_AND_LIGHT_NAME: "同时导出黑暗和明亮主题风格的图像",
-  EXPORT_BOTH_DARK_AND_LIGHT_DESC:  "若开启，Excalidraw 将导出两个文件：filename.dark.png（或 filename.dark.svg）和 filename.light.png（或 filename.light.svg）。<br>"+
+  EXPORT_BOTH_DARK_AND_LIGHT_DESC: "若开启，Excalidraw 将导出两个文件：filename.dark.png（或 filename.dark.svg）和 filename.light.png（或 filename.light.svg）。<br>" +
     "该选项可作用于“自动导出 SVG 副本”、“自动导出 PNG 副本”，以及其他的手动的导出命令。",
   COMPATIBILITY_HEAD: "兼容性设置",
   COMPATIBILITY_DESC: "如果没有特殊原因（例如您想同时在 VSCode / Logseq 和 Obsidian 中使用 Excalidraw），建议您使用 Markdown 格式的绘图文件，而不是旧的 excalidraw.com 格式，因为本插件的很多功能在旧格式中无法使用。",
   DUMMY_TEXT_ELEMENT_LINT_SUPPORT_NAME: "代码格式化（Linting）兼容性",
   DUMMY_TEXT_ELEMENT_LINT_SUPPORT_DESC: "Excalidraw 对 <code># Excalidraw Data</code> 下的文件结构非常敏感。文档的自动代码格式化（linting）可能会在 Excalidraw 数据中造成错误。" +
-    "虽然我已经努力使数据加载对自动代码格式化（linting）变更具有一定的抗性，但这种解决方案并非万无一失。<br>"+
+    "虽然我已经努力使数据加载对自动代码格式化（linting）变更具有一定的抗性，但这种解决方案并非万无一失。<br>" +
     "<mark>最好的方法是避免使用不同的插件对 Excalidraw 文档进行自动更改。</mark><br>" +
     "如果出于某些合理的原因，您决定忽略我的建议并配置了 Excalidraw 文件的自动代码格式化，那么可以使用这个设置<br> " +
     "<code>## Text Elements</code> 部分对空行很敏感。一种常见的代码格式化是在章节标题后添加一个空行。但对于 Excalidraw 来说，这将破坏/改变您绘图中的第一个文本元素。" +
@@ -762,7 +760,7 @@ FILENAME_HEAD: "文件名",
     "此外，您打开旧格式绘图文件时将不再收到警告消息。",
   MATHJAX_NAME: "MathJax (LaTeX) 的 javascript 库服务器",
   MATHJAX_DESC: "如果您在绘图中使用 LaTeX，插件需要从服务器获取并加载一个 javascript 库。" +
-    "如果您的网络无法访问某些库服务器，可以尝试通过此选项更换库服务器。"+
+    "如果您的网络无法访问某些库服务器，可以尝试通过此选项更换库服务器。" +
     "更改此选项后，您可能需要重启 Obsidian 来使其生效。",
   LATEX_DEFAULT_NAME: "插入 LaTeX 时的默认表达式",
   LATEX_DEFAULT_DESC: "允许留空。允许使用类似 <code>\\color{white}</code> 的格式化表达式。",
@@ -816,7 +814,7 @@ FILENAME_HEAD: "文件名",
     "这样，整个 Excalidraw Markdown 都会淡化，包括 # Text Elements。 副作用是您将无法在其他 Markdown 笔记中引用文本块，即 %% 注释部分之后的内容。这应该不是大问题。" +
     "如果您想编辑 Excalidraw Markdown 脚本，只需切换到 Markdown 视图模式并暂时删除 %% 注释。",
   EXCALIDRAW_PROPERTIES_NAME: "将 Excalidraw 属性加载到 Obsidian 的自动提示中",
-  EXCALIDRAW_PROPERTIES_DESC: "切换此设置以在插件启动时将 Excalidraw 文档属性加载到 Obsidian 的属性自动提示中。"+
+  EXCALIDRAW_PROPERTIES_DESC: "切换此设置以在插件启动时将 Excalidraw 文档属性加载到 Obsidian 的属性自动提示中。" +
    "启用此功能简化了 Excalidraw 前置属性的使用，使您能够利用许多强大的设置。如果您不希望自动加载这些属性，" +
    "您可以禁用此功能，但您将需要手动从自动提示中移除任何不需要的属性。" +
    "请注意，启用此设置需要重启插件，因为属性是在启动时加载的。",
@@ -831,9 +829,9 @@ FILENAME_HEAD: "文件名",
     "此外，在excalidraw.com 或其他 Excalidraw 版本中，默认的本地字体字体将使用系统字体。",
   FOURTH_FONT_NAME: "本地字体文件",
   FOURTH_FONT_DESC:
-    "从您的库中选择一个 .otf、.ttf、.woff 或 .woff2 字体文件作为本地字体使用。"+
-    "如果没有选择文件，Excalidraw 将默认使用 Virgil 字体。"+
-    "为了获得最佳性能，建议使用 .woff2 文件，因为当导出到 SVG 格式的图像时，Excalidraw 只会编码必要的字形。"+
+    "从您的库中选择一个 .otf、.ttf、.woff 或 .woff2 字体文件作为本地字体使用。" +
+    "如果没有选择文件，Excalidraw 将默认使用 Virgil 字体。" +
+    "为了获得最佳性能，建议使用 .woff2 文件，因为当导出到 SVG 格式的图像时，Excalidraw 只会编码必要的字形。" +
     "其他字体格式将在导出文件中嵌入整个字体，可能会导致文件大小显著增加。<mark>译者注：</mark>您可以在<a href='https://wangchujiang.com/free-font/' target='_blank'>Free Font</a>获取免费商用中文手写字体。",
   OFFLINE_CJK_NAME: "离线 CJK 字体支持",
   OFFLINE_CJK_DESC:
@@ -1035,7 +1033,7 @@ FILENAME_HEAD: "文件名",
   SCRIPT_UPDATES_AVAILABLE: `脚本更新可用 - 请检查脚本存储。\n\n ${ DEVICE . isDesktop ? `此消息可在控制台日志中查看 ( ${ DEVICE . isMacOS ? "CMD+OPT+i" : "CTRL+SHIFT+i" } )\n\n` : "" } 如果您已将脚本组织到脚本存储文件夹下的子文件夹中，并且存在同一脚本的多个副本，可能需要清理未使用的版本以消除此警报。对于不需要更新的私人脚本副本，请将它们存储在脚本存储文件夹之外。` ,
   ERROR_PNG_TOO_LARGE: "导出 PNG 时出错 - PNG 文件过大，请尝试较小的分辨率",
 
-  // ModifierkeyHelper.ts
+  //modifierkeyHelper.ts
   // WebBrowserDragAction
   WEB_DRAG_IMPORT_IMAGE: "导入图片到 Vault" ,
   WEB_DRAG_IMAGE_URL: "通过 URL 插入图片或 YouTube 缩略图" ,
@@ -1061,98 +1059,98 @@ FILENAME_HEAD: "文件名",
   LINK_CLICK_NEW_TAB: "在新标签页中打开" ,
   LINK_CLICK_MD_PROPS: "显示 Markdown 图片属性对话框（仅在嵌入 Markdown 文档为图片时适用）" ,
 
-// 导出对话框
-// 对话框和标签页
-EXPORTDIALOG_TITLE: "导出图形",
-EXPORTDIALOG_TAB_IMAGE: "图像",
-EXPORTDIALOG_TAB_PDF: "PDF",
-// 设置持久化
-EXPORTDIALOG_SAVE_SETTINGS: "将图像设置保存到文件 doc.properties 吗？",
-EXPORTDIALOG_SAVE_SETTINGS_SAVE: "保存为预设",
-EXPORTDIALOG_SAVE_SETTINGS_ONETIME: "仅本次使用",
-// 图像设置
-EXPORTDIALOG_IMAGE_SETTINGS: "图像",
-EXPORTDIALOG_IMAGE_DESC: "PNG 支持透明。外部文件可以包含 Excalidraw 场景数据。",
-EXPORTDIALOG_PADDING: "边距",
-EXPORTDIALOG_SCALE: "缩放",
-EXPORTDIALOG_CURRENT_PADDING: "当前边距：",
-EXPORTDIALOG_SIZE_DESC: "缩放会影响输出大小",
-EXPORTDIALOG_SCALE_VALUE: "缩放：",
-EXPORTDIALOG_IMAGE_SIZE: "大小：",
-// 主题和背景
-EXPORTDIALOG_EXPORT_THEME: "主题",
-EXPORTDIALOG_THEME_LIGHT: "浅色",
-EXPORTDIALOG_THEME_DARK: "深色",
-EXPORTDIALOG_BACKGROUND: "背景",
-EXPORTDIALOG_BACKGROUND_TRANSPARENT: "透明",
-EXPORTDIALOG_BACKGROUND_USE_COLOR: "使用场景颜色",
-// 选择
-EXPORTDIALOG_SELECTED_ELEMENTS: "导出",
-EXPORTDIALOG_SELECTED_ALL: "整个场景",
-EXPORTDIALOG_SELECTED_SELECTED: "仅选中部分",
-// 导出选项
-EXPORTDIALOG_EMBED_SCENE: "包含场景数据吗？",
-EXPORTDIALOG_EMBED_YES: "是",
-EXPORTDIALOG_EMBED_NO: "否",
-// PDF 设置
-EXPORTDIALOG_PDF_SETTINGS: "PDF",
-EXPORTDIALOG_PAGE_SIZE: "页面大小",
-EXPORTDIALOG_PAGE_ORIENTATION: "方向",
-EXPORTDIALOG_ORIENTATION_PORTRAIT: "纵向",
-EXPORTDIALOG_ORIENTATION_LANDSCAPE: "横向",
-EXPORTDIALOG_PDF_FIT_TO_PAGE: "页面适配",
-EXPORTDIALOG_PDF_FIT_OPTION: "适配页面",
-EXPORTDIALOG_PDF_FIT_2_OPTION: "适配至最多 2 页" ,
-EXPORTDIALOG_PDF_FIT_4_OPTION: "适配至最多 4 页" ,
-EXPORTDIALOG_PDF_FIT_6_OPTION: "适配至最多 6 页" ,
-EXPORTDIALOG_PDF_FIT_8_OPTION: "适配至最多 8 页" ,
-EXPORTDIALOG_PDF_FIT_12_OPTION: "适配至最多 12 页" ,
-EXPORTDIALOG_PDF_FIT_16_OPTION: "适配至最多 16 页" ,
-EXPORTDIALOG_PDF_SCALE_OPTION: "使用图像缩放（可能跨多页）",
-EXPORTDIALOG_PDF_PAPER_COLOR: "纸张颜色",
-EXPORTDIALOG_PDF_PAPER_WHITE: "白色",
-EXPORTDIALOG_PDF_PAPER_SCENE: "使用场景颜色",
-EXPORTDIALOG_PDF_PAPER_CUSTOM: "自定义颜色",
-EXPORTDIALOG_PDF_ALIGNMENT: "页面位置",
-EXPORTDIALOG_PDF_ALIGN_CENTER: "居中",
-EXPORTDIALOG_PDF_ALIGN_CENTER_LEFT: "左对齐居中" ,
-EXPORTDIALOG_PDF_ALIGN_CENTER_RIGHT: "右对齐居中" ,
-EXPORTDIALOG_PDF_ALIGN_TOP_LEFT: "左上角",
-EXPORTDIALOG_PDF_ALIGN_TOP_CENTER: "顶部居中",
-EXPORTDIALOG_PDF_ALIGN_TOP_RIGHT: "右上角",
-EXPORTDIALOG_PDF_ALIGN_BOTTOM_LEFT: "左下角",
-EXPORTDIALOG_PDF_ALIGN_BOTTOM_CENTER: "底部居中",
-EXPORTDIALOG_PDF_ALIGN_BOTTOM_RIGHT: "右下角",
-EXPORTDIALOG_PDF_MARGIN: "边距",
-EXPORTDIALOG_PDF_MARGIN_NONE: "无",
-EXPORTDIALOG_PDF_MARGIN_TINY: "小",
-EXPORTDIALOG_PDF_MARGIN_NORMAL: "正常",
-EXPORTDIALOG_SAVE_PDF_SETTINGS: "保存 PDF 设置",
-EXPORTDIALOG_SAVE_CONFIRMATION: "PDF 配置已保存为插件默认设置",
-// 按钮
-EXPORTDIALOG_PNGTOFILE: "导出 PNG 文件",
-EXPORTDIALOG_SVGTOFILE: "导出 SVG 文件",
-EXPORTDIALOG_PNGTOVAULT: "PNG 保存到 Vault",
-EXPORTDIALOG_SVGTOVAULT: "SVG 保存到 Vault",
-EXPORTDIALOG_EXCALIDRAW: "Excalidraw",
-EXPORTDIALOG_PNGTOCLIPBOARD: "PNG 复制到剪贴板",
-EXPORTDIALOG_SVGTOCLIPBOARD: "SVG 复制到剪贴板",
-EXPORTDIALOG_PDF: "导出 PDF 文件",
+  //ExportDialog
+  // Dialog and tabs
+  EXPORTDIALOG_TITLE: "导出图形",
+  EXPORTDIALOG_TAB_IMAGE: "图像",
+  EXPORTDIALOG_TAB_PDF: "PDF",
+  // Settings persistence
+  EXPORTDIALOG_SAVE_SETTINGS: "将图像设置保存到文件 doc.properties 吗？",
+  EXPORTDIALOG_SAVE_SETTINGS_SAVE: "保存为预设",
+  EXPORTDIALOG_SAVE_SETTINGS_ONETIME: "仅本次使用",
+  // Image settings
+  EXPORTDIALOG_IMAGE_SETTINGS: "图像",
+  EXPORTDIALOG_IMAGE_DESC: "PNG 支持透明。外部文件可以包含 Excalidraw 场景数据。",
+  EXPORTDIALOG_PADDING: "边距",
+  EXPORTDIALOG_SCALE: "缩放",
+  EXPORTDIALOG_CURRENT_PADDING: "当前边距：",
+  EXPORTDIALOG_SIZE_DESC: "缩放会影响输出大小",
+  EXPORTDIALOG_SCALE_VALUE: "缩放：",
+  EXPORTDIALOG_IMAGE_SIZE: "大小：",
+  // Theme and background
+  EXPORTDIALOG_EXPORT_THEME: "主题",
+  EXPORTDIALOG_THEME_LIGHT: "浅色",
+  EXPORTDIALOG_THEME_DARK: "深色",
+  EXPORTDIALOG_BACKGROUND: "背景",
+  EXPORTDIALOG_BACKGROUND_TRANSPARENT: "透明",
+  EXPORTDIALOG_BACKGROUND_USE_COLOR: "使用场景颜色",
+  // Selection
+  EXPORTDIALOG_SELECTED_ELEMENTS: "导出",
+  EXPORTDIALOG_SELECTED_ALL: "整个场景",
+  EXPORTDIALOG_SELECTED_SELECTED: "仅选中部分",
+  // Export options
+  EXPORTDIALOG_EMBED_SCENE: "包含场景数据吗？",
+  EXPORTDIALOG_EMBED_YES: "是",
+  EXPORTDIALOG_EMBED_NO: "否",
+  // PDF settings
+  EXPORTDIALOG_PDF_SETTINGS: "PDF",
+  EXPORTDIALOG_PAGE_SIZE: "页面大小",
+  EXPORTDIALOG_PAGE_ORIENTATION: "方向",
+  EXPORTDIALOG_ORIENTATION_PORTRAIT: "纵向",
+  EXPORTDIALOG_ORIENTATION_LANDSCAPE: "横向",
+  EXPORTDIALOG_PDF_FIT_TO_PAGE: "页面适配",
+  EXPORTDIALOG_PDF_FIT_OPTION: "适配页面",
+  EXPORTDIALOG_PDF_FIT_2_OPTION: "适配至最多 2 页" ,
+  EXPORTDIALOG_PDF_FIT_4_OPTION: "适配至最多 4 页" ,
+  EXPORTDIALOG_PDF_FIT_6_OPTION: "适配至最多 6 页" ,
+  EXPORTDIALOG_PDF_FIT_8_OPTION: "适配至最多 8 页" ,
+  EXPORTDIALOG_PDF_FIT_12_OPTION: "适配至最多 12 页" ,
+  EXPORTDIALOG_PDF_FIT_16_OPTION: "适配至最多 16 页" ,
+  EXPORTDIALOG_PDF_SCALE_OPTION: "使用图像缩放（可能跨多页）",
+  EXPORTDIALOG_PDF_PAPER_COLOR: "纸张颜色",
+  EXPORTDIALOG_PDF_PAPER_WHITE: "白色",
+  EXPORTDIALOG_PDF_PAPER_SCENE: "使用场景颜色",
+  EXPORTDIALOG_PDF_PAPER_CUSTOM: "自定义颜色",
+  EXPORTDIALOG_PDF_ALIGNMENT: "页面位置",
+  EXPORTDIALOG_PDF_ALIGN_CENTER: "居中",
+  EXPORTDIALOG_PDF_ALIGN_CENTER_LEFT: "左对齐居中" ,
+  EXPORTDIALOG_PDF_ALIGN_CENTER_RIGHT: "右对齐居中" ,
+  EXPORTDIALOG_PDF_ALIGN_TOP_LEFT: "左上角",
+  EXPORTDIALOG_PDF_ALIGN_TOP_CENTER: "顶部居中",
+  EXPORTDIALOG_PDF_ALIGN_TOP_RIGHT: "右上角",
+  EXPORTDIALOG_PDF_ALIGN_BOTTOM_LEFT: "左下角",
+  EXPORTDIALOG_PDF_ALIGN_BOTTOM_CENTER: "底部居中",
+  EXPORTDIALOG_PDF_ALIGN_BOTTOM_RIGHT: "右下角",
+  EXPORTDIALOG_PDF_MARGIN: "边距",
+  EXPORTDIALOG_PDF_MARGIN_NONE: "无",
+  EXPORTDIALOG_PDF_MARGIN_TINY: "小",
+  EXPORTDIALOG_PDF_MARGIN_NORMAL: "正常",
+  EXPORTDIALOG_SAVE_PDF_SETTINGS: "保存 PDF 设置",
+  EXPORTDIALOG_SAVE_CONFIRMATION: "PDF 配置已保存为插件默认设置",
+  // Buttons
+  EXPORTDIALOG_PNGTOFILE: "导出 PNG 文件",
+  EXPORTDIALOG_SVGTOFILE: "导出 SVG 文件",
+  EXPORTDIALOG_PNGTOVAULT: "PNG 保存到 Vault",
+  EXPORTDIALOG_SVGTOVAULT: "SVG 保存到 Vault",
+  EXPORTDIALOG_EXCALIDRAW: "Excalidraw",
+  EXPORTDIALOG_PNGTOCLIPBOARD: "PNG 复制到剪贴板",
+  EXPORTDIALOG_SVGTOCLIPBOARD: "SVG 复制到剪贴板",
+  EXPORTDIALOG_PDF: "导出 PDF 文件",
 
-EXPORTDIALOG_PDF_PROGRESS_NOTICE: "正在导出 PDF。如果图像较大，可能需要一些时间。" ,
-EXPORTDIALOG_PDF_PROGRESS_DONE: "导出完成" ,
-EXPORTDIALOG_PDF_PROGRESS_ERROR: "导出 PDF 时出错，请检查开发者控制台以获取详细信息" ,
+  EXPORTDIALOG_PDF_PROGRESS_NOTICE: "正在导出 PDF。如果图像较大，可能需要一些时间。" ,
+  EXPORTDIALOG_PDF_PROGRESS_DONE: "导出完成" ,
+  EXPORTDIALOG_PDF_PROGRESS_ERROR: "导出 PDF 时出错，请检查开发者控制台以获取详细信息" ,
 
-// Screenshot tab
-EXPORTDIALOG_NOT_AVAILALBE: "抱歉，此功能仅在绘图在主 Obsidian 工作区打开时可用。",
-EXPORTDIALOG_TAB_SCREENSHOT: "截图" ,
-EXPORTDIALOG_SCREENSHOT_DESC: "截图将包括可嵌入的内容，例如 markdown 页面、YouTube、网站等。它们仅在桌面端可用，无法自动导出，并且仅支持 PNG 格式。" ,
-SCREENSHOT_DESKTOP_ONLY: "截图功能仅在桌面端可用" ,
-SCREENSHOT_FILE_SUCCESS: "截图已保存到仓库" ,
-SCREENSHOT_CLIPBOARD_SUCCESS: "截图已复制到剪贴板" ,
-SCREENSHOT_CLIPBOARD_ERROR: "无法复制截图到剪贴板：" ,
-SCREENSHOT_ERROR: "截图出错 - 请查看控制台日志" ,
+  // Screenshot tab
+  EXPORTDIALOG_NOT_AVAILALBE: "抱歉，此功能仅在绘图在主 Obsidian 工作区打开时可用。",
+  EXPORTDIALOG_TAB_SCREENSHOT: "截图" ,
+  EXPORTDIALOG_SCREENSHOT_DESC: "截图将包括可嵌入的内容，例如 markdown 页面、YouTube、网站等。它们仅在桌面端可用，无法自动导出，并且仅支持 PNG 格式。" ,
+  SCREENSHOT_DESKTOP_ONLY: "截图功能仅在桌面端可用" ,
+  SCREENSHOT_FILE_SUCCESS: "截图已保存到仓库" ,
+  SCREENSHOT_CLIPBOARD_SUCCESS: "截图已复制到剪贴板" ,
+  SCREENSHOT_CLIPBOARD_ERROR: "无法复制截图到剪贴板：" ,
+  SCREENSHOT_ERROR: "截图出错 - 请查看控制台日志" ,
 
-// exportUtils.ts
-PDF_EXPORT_DESKTOP_ONLY: "PDF 导出功能仅限桌面端使用" ,
+  //exportUtils.ts
+  PDF_EXPORT_DESKTOP_ONLY: "PDF 导出功能仅限桌面端使用" ,
 };


### PR DESCRIPTION
本 PR 为 https://github.com/zsviczian/obsidian-excalidraw-plugin/pull/2418 的移植，原文如下：

---

为了便于与原始来源进行比较，本 PR 不包含任何实际内容更改。

为了方便翻译人员，格式调整不仅应用于 `en.ts`，还应用于现有的翻译文件 `ru.ts` 和 `zh-cn.ts`。

**为什么统一空白字符？**

在使用差异编辑器比较 `en.ts` 与其他翻译文件时，不一致的空白字符可能导致无关的差异。这使得识别真正的翻译差异变得更加困难，并增加了维护难度。

统一的格式也使得检测缺失的翻译变得更加容易——例如，通过比较行数或通过视觉检查发现空缺。

简而言之，在翻译前统一空白字符对于保持干净且易于维护的差异至关重要。

**做了哪些更改？**

- 删除了行尾不必要的空白字符。
- 将句子内的多个连续空格替换为单个空格。
- 统一了 JSON 键值格式，遵循 `键: 值` 的格式，确保所有键后跟一个冒号和一个空格（替换不一致的 `键 : 值` 格式）。
- 清理了 `zh-cn.ts` 中注释行（`// ...`）内的不必要的空白和翻译编辑，使其与 `en.ts` 一致。
    - 与空白字符类似，JSON 文件中的注释不影响实际翻译。因此，减少不必要的差异有助于保持差异的干净和有意义。

如果您有任何疑虑，请随时联系。

---

@dmscode 可以看看还有没有需要改的或者其他建议。